### PR TITLE
Resolve error produced by empty outputs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,5 +10,3 @@ inputs:
   creds:
     description: 'YAML Array of credential objects (`machine`, `login`, `password`)'
     required: true
-outputs:
-# None

--- a/action.yml
+++ b/action.yml
@@ -10,4 +10,5 @@ inputs:
   creds:
     description: 'YAML Array of credential objects (`machine`, `login`, `password`)'
     required: true
-outputs: # none
+outputs:
+# None


### PR DESCRIPTION
Hello! It seems that an error started coming up in this GitHub Action about 2 days ago, where the empty `output:` section threw the following error (full output from job):

```
Current runner version: '2.272.0'
Operating System
  Ubuntu
  18.04.4
  LTS
Virtual Environment
  Environment: ubuntu-18.04
  Version: 20200726.1
  Included Software: https://github.com/actions/virtual-environments/blob/ubuntu18/20200726.1/images/linux/Ubuntu1804-README.md
Prepare workflow directory
Prepare all required actions
Download action repository 'actions/checkout@v2'
Download action repository 'actions/setup-go@v1'
Download action repository 'little-core-labs/netrc-creds@v1'
##[error]little-core-labs/netrc-creds/v1/action.yml (Line: 13, Col: 9): Unexpected value ''
##[error]little-core-labs/netrc-creds/v1/action.yml (Line: 13, Col: 9): Unexpected value ''
##[error]System.ArgumentException: Unexpected type 'NullToken' encountered while reading 'outputs'. The type 'MappingToken' was expected.
   at GitHub.DistributedTask.ObjectTemplating.Tokens.TemplateTokenExtensions.AssertMapping(TemplateToken value, String objectDescription)
   at GitHub.Runner.Worker.ActionManifestManager.Load(IExecutionContext executionContext, String manifestFile)
##[error]Fail to load little-core-labs/netrc-creds/v1/action.yml
```

I forked your repo, introducing my change, which resolved the issue.
